### PR TITLE
10815: 숫자 카드;

### DIFF
--- a/BaekJoon/Algorithm_study/10815 Silver 숫자 카드.py
+++ b/BaekJoon/Algorithm_study/10815 Silver 숫자 카드.py
@@ -1,0 +1,15 @@
+import sys
+
+
+N = int(input())
+have_cards = set(input().strip().split())
+M = int(input())
+searching_cards = input().strip().split()
+
+result = []
+for card in searching_cards:
+    if card in have_cards:
+        result.append(str(1))
+    else:
+        result.append(str(0))
+print(' '.join(result))


### PR DESCRIPTION
hash 테이블로 고유 해시값을 통해 찾아와서 불러와야 시간초과 해결 됨.

파이썬에서 set(하고 딕셔너리)는 내부적으로 해시 테이블이란 자료구조로 이루어졌습니다.

해시 테이블에 대해 간략히 설명드리면,

각 값들을 해시함수(hash map) 에 넣으면 각 값들의 고유값이 나옵니다.

이렇게 나온 고유값들로 모든 값들에 빠르게 접근하는 자료구조가 해시 테이블입니다.

리스트에서 값을 찾을 때는 순차적으로 값을 찾습니다.

M_data 에 있는 각 값들을 찾을 때, 맨 앞에서부터 하나 하나 비교해서 찾습니다.

최악의 결과로는, 찾고자 하는 값이 맨 뒤에 있을 때 (또는 찾고자 하는 값이 없는 경우),

처음부터 시작해서 맨 뒤까지 계속 찾습니다.

즉, 리스트에서 in 으로 찾을 때는 최악인 경우 O(n) 시간 복잡도를 갖습니다.

반면, 위에서 말씀드린 해시 테이블인 경우, 각 값들의 고유 해시값으로 인해 평균적으로 O(1) 이라는 시간 복잡도로 값을 찾을 수 있습니다.

배열 (리스트) 와 해시 테이블 (set) 의 탐색 속도 차이 때문에 어느 하나는 시간 초과, 다른 하나는 성공이 됩니다.

(해시 테이블 관련해서는 질문자분께서 한 번 찾아보세요. 해시 테이블의 장/단점들 꼭 알아두셔야 합니다.

해시 테이블 쓰는게 더 유리한 경우, 해시 테이블 대신 그냥 리스트 쓰는게 더 유리한 경우 등등이요)